### PR TITLE
Release v0.4.4 - Critical Bug Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update SonarCloud GitHub Action from deprecated `SonarSource/sonarcloud-github-action@master` to `sonarqube-scan-action` (backlog item for next release)
 
+## [0.4.4] - 2025-10-31 - CRITICAL BUG FIX 🐛
+
+### Fixed
+- **CRITICAL: Message consumption bug fixed** - Consumer groups now read all messages from stream start
+  - Bug: Groups created with `id="$"` only saw messages added AFTER group creation
+  - Fix: Changed to `id="0"` to read from beginning of stream, ensuring ALL messages are visible
+  - Impact: Agents can now receive messages even if group was created after messages were sent
+  - Fixes "deaf and blind" agents in live-fire testing
+- **Test isolation fixed** - Environment variable tests now properly isolate from `~/.env` file
+
+### Migration Notes
+- **No breaking changes** - bug fix only, fully backward compatible
+- Existing consumer groups will continue to work
+- New groups created after this version will correctly read all messages from stream start
+
+### Technical Notes
+- Fix confirmed via live-fire testing
+- All tests passing
+- Message consumption now works reliably in production deployments
+
 ## [0.4.3] - 2025-10-30 - ENVIRONMENT VARIABLE SUPPORT 🔧
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beast-mailbox-core"
-version = "0.4.3"
+version = "0.4.4"
 description = "Redis-backed mailbox utilities from Beast Mode"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Critical bug fix release for message consumption bug.

## Changes
- Fixed consumer group creation to read all messages (not just new ones)
- Fixed test isolation issues
- All tests passing
- Live-fire testing confirmed fix

## Critical Bug Fixed
Consumer groups created with id='$' only saw messages added AFTER group creation. Changed to id='0' to read from beginning of stream.

Ready for release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes critical consumer group offset bug to read all messages and bumps version to 0.4.4.
> 
> - **Fixed**
>   - Consumer groups now created with `id="0"` (was `"$"`) to read from the beginning of the stream.
>   - Test isolation for environment variable handling to avoid interference from `~/.env`.
> - **Release**
>   - Bump version to `0.4.4` in `pyproject.toml`.
>   - Add `0.4.4` release notes to `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33d5b75110daed4c734a1df9dad7aaddada4195e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->